### PR TITLE
Use "unknown" product version instead of throwing exception

### DIFF
--- a/dropwizard-version-info/src/main/java/com/palantir/dropwizard/versioninfo/VersionInfoBundle.java
+++ b/dropwizard-version-info/src/main/java/com/palantir/dropwizard/versioninfo/VersionInfoBundle.java
@@ -12,6 +12,9 @@ import com.google.common.io.Resources;
 import io.dropwizard.Bundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -24,6 +27,7 @@ import java.util.Properties;
  */
 public final class VersionInfoBundle implements Bundle {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(VersionInfoBundle.class);
     private static final String DEFAULT_PATH = "version.properties";
     private static final String UNKNOWN = "unknown";
 
@@ -53,15 +57,13 @@ public final class VersionInfoBundle implements Bundle {
 
     public static String readVersion(String resourcePath) {
         Properties properties = new Properties();
-        String result;
         try {
             URL url = Resources.getResource(resourcePath);
             InputStream versionProperties = Resources.asByteSource(url).openStream();
             properties.load(versionProperties);
-            result = properties.getProperty("productVersion", UNKNOWN);
         } catch (IOException | IllegalArgumentException e) {
-            throw new RuntimeException("Could not read properties file '" + resourcePath + "'.", e);
+            LOGGER.warn("Could not read properties file '" + resourcePath + "'.", e);
         }
-        return result;
+        return properties.getProperty("productVersion", UNKNOWN);
     }
 }

--- a/dropwizard-version-info/src/main/java/com/palantir/dropwizard/versioninfo/VersionInfoBundle.java
+++ b/dropwizard-version-info/src/main/java/com/palantir/dropwizard/versioninfo/VersionInfoBundle.java
@@ -12,13 +12,13 @@ import com.google.common.io.Resources;
 import io.dropwizard.Bundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Bundle to read product version from a file and expose it as a resource.

--- a/dropwizard-version-info/src/test/java/com/palantir/dropwizard/versioninfo/VersionInfoBundleTests.java
+++ b/dropwizard-version-info/src/test/java/com/palantir/dropwizard/versioninfo/VersionInfoBundleTests.java
@@ -5,8 +5,6 @@
 package com.palantir.versioninfo;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -21,7 +19,6 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -46,13 +43,8 @@ public final class VersionInfoBundleTests {
 
     @Test
     public void testVersionPropertiesFileDoesNotExist() {
-        try {
-            new VersionInfoBundle("filedoesntexist.properties");
-            fail();
-        } catch (RuntimeException e) {
-            assertThat(e.getCause(), IsInstanceOf.instanceOf(IllegalArgumentException.class));
-            assertEquals(e.getMessage(), "Could not read properties file 'filedoesntexist.properties'.");
-        }
+        String versionInfo = VersionInfoBundle.readVersion("filedoesntexist.properties");
+        assertEquals(versionInfo, "unknown");
     }
 
     @Test


### PR DESCRIPTION
In the case where the '.properties' file can't be found, we should use
"unknown" instead of throwing an exception and making callers catch it.

Addresses #13.
